### PR TITLE
ci: Fix wrong release version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,12 +35,8 @@ jobs:
       - uses: dart-lang/setup-dart@v1
       - name: Install dependencies
         run: dart pub get
-      - name: Get release version
-        run: |
-          VERSION=${{ github.event.release.tag_name }}
-          echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
       - name: Update version
-        run: dart run bull pub_version --version=${VERSION}
+        run: dart run bull pub_version --version=${{ github.event.release.tag_name }}
       - name: Commit updated pubspec
         uses: stefanzweifel/git-auto-commit-action@v4
         with:


### PR DESCRIPTION
The release version is wrong.

- Related: https://github.com/dev-yakuza/bull/actions/runs/5037674756/jobs/9034669581#step:9:10

So, I fix it.