### PR TITLE
refactor: Use bin code instead of src code

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -1,4 +1,4 @@
 {
-  "words": ["pubspec", "Lefthook", "yakuza"],
-  "ignorePaths": ["LICENSE", "pubspec.yaml"]
+  "words": ["pubspec", "Lefthook"],
+  "ignorePaths": ["LICENSE", "pubspec.yaml", "CHANGELOG.md"]
 }

--- a/bin/bull.dart
+++ b/bin/bull.dart
@@ -2,13 +2,12 @@ import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 import 'package:bull/collections/pub_version.dart';
 
-void main(List<String> arguments) {
-  NoneTraceCommandRunner(
+Future<void> main(List<String> arguments) async {
+  final cmd = NoneTraceCommandRunner(
     "bull",
     "A collection of convenient and useful Command-Line interfaces for development.",
-  )
-    ..addCommand(PubVersion())
-    ..run(arguments);
+  )..addCommand(PubVersion());
+  await cmd.run(arguments);
 }
 
 class NoneTraceCommandRunner extends CommandRunner {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,4 +12,5 @@ dependencies:
 
 dev_dependencies:
   lints: ^2.0.0
+  run_with_print: ^0.0.1
   test: ^1.21.0

--- a/test/collections/pub_version_test.dart
+++ b/test/collections/pub_version_test.dart
@@ -1,12 +1,12 @@
 import 'dart:io';
 
-import 'package:args/command_runner.dart';
-import 'package:bull/collections/pub_version.dart';
+import 'package:run_with_print/run_with_print.dart';
 import 'package:test/test.dart';
+
+import '../../bin/bull.dart' as bull;
 
 void main() {
   const tempFile = 'test/collections/temp.yaml';
-  final runner = CommandRunner('test', 'test')..addCommand(PubVersion());
 
   setUp(() {
     final file = File(tempFile);
@@ -20,87 +20,83 @@ void main() {
   });
 
   group('Update', () {
-    test('When version is major, update major version and reset others',
-        () async {
+    test('When version is major, update major version and reset others', () {
       expect(File(tempFile).readAsStringSync(), 'version: 2.5.7');
-      await runner.run(
+      bull.main(
         ['pub_version', '--version', 'major', '--file-path', tempFile],
       );
       expect(File(tempFile).readAsStringSync(), 'version: 3.0.0');
-      await runner.run(
+      bull.main(
         ['pub_version', '--version', 'major', '--file-path', tempFile],
       );
       expect(File(tempFile).readAsStringSync(), 'version: 4.0.0');
     });
 
-    test('When version is minor, update minor version and reset patch',
-        () async {
+    test('When version is minor, update minor version and reset patch', () {
       expect(File(tempFile).readAsStringSync(), 'version: 2.5.7');
-      await runner.run(
+      bull.main(
         ['pub_version', '--version', 'minor', '--file-path', tempFile],
       );
       expect(File(tempFile).readAsStringSync(), 'version: 2.6.0');
-      await runner.run(
+      bull.main(
         ['pub_version', '--version', 'minor', '--file-path', tempFile],
       );
       expect(File(tempFile).readAsStringSync(), 'version: 2.7.0');
     });
 
-    test('When version is patch, update patch version and reset build',
-        () async {
+    test('When version is patch, update patch version and reset build', () {
       expect(File(tempFile).readAsStringSync(), 'version: 2.5.7');
-      await runner.run(
+      bull.main(
         ['pub_version', '--version', 'patch', '--file-path', tempFile],
       );
       expect(File(tempFile).readAsStringSync(), 'version: 2.5.8');
-      await runner.run(
+      bull.main(
         ['pub_version', '--version', 'patch', '--file-path', tempFile],
       );
       expect(File(tempFile).readAsStringSync(), 'version: 2.5.9');
     });
 
-    test('When version is build, update build version', () async {
+    test('When version is build, update build version', () {
       expect(File(tempFile).readAsStringSync(), 'version: 2.5.7');
-      await runner.run(
+      bull.main(
         ['pub_version', '--version', 'build', '--file-path', tempFile],
       );
       expect(File(tempFile).readAsStringSync(), 'version: 2.5.7+1');
-      await runner.run(
+      bull.main(
         ['pub_version', '--version', 'build', '--file-path', tempFile],
       );
       expect(File(tempFile).readAsStringSync(), 'version: 2.5.7+2');
     });
 
-    test('When version is specific version, update version same as it',
-        () async {
+    test('When version is specific version, update version same as it', () {
       expect(File(tempFile).readAsStringSync(), 'version: 2.5.7');
-      await runner.run(
+      bull.main(
         ['pub_version', '--version', '1.0.0', '--file-path', tempFile],
       );
       expect(File(tempFile).readAsStringSync(), 'version: 1.0.0');
-      await runner.run(
+      bull.main(
         ['pub_version', '--version', '2.7.7-dev.4', '--file-path', tempFile],
       );
       expect(File(tempFile).readAsStringSync(), 'version: 2.7.7-dev.4');
     });
 
     group('Error occurs', () {
-      test('If no version is passed', () async {
-        try {
-          await runner.run(['pub_version', '--file-path', tempFile]);
-        } catch (e) {
-          expect(e, '[ERROR] The version option is required.');
-        }
+      test('If no version is passed', () {
+        runWithPrint((logs) async {
+          await bull.main(['pub_version', '--file-path', tempFile]);
+
+          expect(logs[0], '[ERROR] The version option is required.');
+        });
       });
 
-      test('If wrong version is passed', () async {
-        try {
-          await runner.run(
+      test('If wrong version is passed', () {
+        runWithPrint((logs) async {
+          await bull.main(
             ['pub_version', '--version', 'abcd', '--file-path', tempFile],
           );
-        } catch (e) {
+
           expect(
-              e,
+              logs[0],
               '''
 [ERROR] abcd is not supported. The version must be
 - major
@@ -110,39 +106,37 @@ void main() {
 - specific version (ex: 2.5.7)
 '''
                   .trim());
-        }
+        });
       });
 
-      test('If file does not exist in pubspec path', () async {
-        try {
-          await runner.run(
-            [
-              'pub_version',
-              '--version',
-              'major',
-              '--file-path',
-              'wrong_path.yaml',
-            ],
-          );
-        } catch (e) {
-          expect(e, '[ERROR] The "wrong_path.yaml" file does not exist.');
-        }
+      test('If file does not exist in pubspec path', () {
+        runWithPrint((logs) async {
+          await bull.main([
+            'pub_version',
+            '--version',
+            'major',
+            '--file-path',
+            'wrong_path.yaml',
+          ]);
+
+          expect(logs[0], '[ERROR] The "wrong_path.yaml" file does not exist.');
+        });
       });
 
-      test('If pubspec file does not have version option', () async {
-        try {
+      test('If pubspec file does not have version option', () {
+        runWithPrint((logs) async {
           final file = File(tempFile);
           file.writeAsStringSync('');
 
-          await runner.run(
+          await bull.main(
             ['pub_version', '--version', 'major', '--file-path', tempFile],
           );
-        } catch (e) {
+
           expect(
-            e,
+            logs[0],
             '[ERROR] The version option in "test/collections/temp.yaml" is not founded.',
           );
-        }
+        });
       });
     });
   });


### PR DESCRIPTION
I refactor using the `bin` code instead of the `src` code.